### PR TITLE
Fix: Remove `--fix` from `dart format` command in `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       - name: Format code
-        run: dart format --fix .
+        run: dart format .
       - name: Publish
         uses: k-paxian/dart-package-publisher@v1.5.1
         with:


### PR DESCRIPTION
The `dart format` command in the `publish.yml` workflow was updated to remove the `--fix` flag. The command will now only check for formatting issues and not automatically fix them.